### PR TITLE
Fix #8 : change cmake Config file path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,10 +105,10 @@ write_basic_package_version_file(${CMAKE_CURRENT_BINARY_DIR}/resilienceConfigVer
 
 # Set install rules
 install(TARGETS resilience EXPORT resilienceTargets
-        LIBRARY DESTINATION lib
-        ARCHIVE DESTINATION lib
-        RUNTIME DESTINATION bin
-        INCLUDES DESTINATION include
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+        INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
         )
 
 install(EXPORT resilienceTargets
@@ -129,7 +129,7 @@ install(DIRECTORY src/resilience DESTINATION include FILES_MATCHING PATTERN "*.h
 if (KR_ENABLE_VELOC)
    install(FILES
         ${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules/FindVeloC.cmake
-        DESTINATION ${CMAKE_INSTALL_PREFIX}/cmake/Modules )
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/Modules )
 
    # Need to install/export VeloC find module for downstream dependencies
    configure_file(cmake/Modules/FindVeloC.cmake Modules/FindVeloC.cmake COPYONLY)
@@ -139,7 +139,7 @@ endif()
 if (KR_ENABLE_HDF5)
   install(FILES
           ${CMAKE_MODULE_PATH}/FindHDF5.cmake
-          DESTINATION ${CMAKE_INSTALL_PREFIX}/cmake/Modules )
+          DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/Modules )
 
   # Need to install/export HDF5 find module for downstream dependencies
   configure_file(cmake/Modules/FindHDF5.cmake Modules/FindHDF5.cmake COPYONLY)


### PR DESCRIPTION
Currently cmake Config is installed in ${CMAKE_INSTALL_PREFIX}/share/resilience/cmake and the cmake Targets file inside ${CMAKE_INSTALL_PREFIX}/cmake. Since cmake Config file tries to access the Targets file from the same directory, making the Config file also installed inside in ${CMAKE_INSTALL_PREFIX}/cmake should solve this. For reference, both Config and Target files of kokkos get installed in the directory ${CMAKE_INSTALL_PREFIX}/lib/cmake. The issue came up while trying to use kokkos-resilience in an out-of-tree cmake file.