### PR TITLE
Fix stdfile automatic checkpointing backend to fetch latest_version properly

### DIFF
--- a/src/resilience/stdfile/StdFileBackend.cpp
+++ b/src/resilience/stdfile/StdFileBackend.cpp
@@ -16,9 +16,13 @@ namespace KokkosResilience {
 
 namespace detail {
 
+std::string versionless_filename(std::string const &filename, std::string const &label) {
+  return filename + "." + label;
+}
+
 std::string full_filename(std::string const &filename, std::string const &label,
                           int version) {
-  return filename + "." + label + "." + std::to_string(version);
+  return versionless_filename(filename, label) + "." + std::to_string(version);
 }
 }  // namespace detail
 
@@ -61,11 +65,25 @@ bool StdFileBackend::restart_available(const std::string &label, int version) {
 
 int StdFileBackend::latest_version(const std::string &label) const noexcept {
   int result = -1;
-  for (int version = 0; /**/; ++version) {
-    std::string filename = detail::full_filename(m_filename, label, version);
-    if (!boost::filesystem::exists(filename)) {
-      result = version - 1;
-      break;
+  std::string filename = detail::versionless_filename(m_filename, label);
+  boost::filesystem::path dir(filename);
+
+  filename = dir.filename().string();
+
+  dir = boost::filesystem::absolute(dir).parent_path();
+
+  for(auto &entry : boost::filesystem::directory_iterator(dir)){
+    if (!boost::filesystem::is_regular_file(entry)) {
+      continue;
+    }
+    if(filename == entry.path().filename().stem().string()){
+        //This is a checkpoint, probably.
+        try{
+            int vers = std::stoi(entry.path().filename().extension().string().substr(1));
+            result = std::max(result,vers);
+        } catch(...) {
+            //Just not the filename format we expected, could be unrelated.
+        }
     }
   }
   return result;


### PR DESCRIPTION
Now iterates over available files, rather than possible iterations.