### PR TITLE
#73: update kokkos to 4.4 and add +openmp

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -58,7 +58,7 @@
       "inherits": ["kr_auto_checkpoint_veloc", "kr_release"],
       "binaryDir": "/opt/build/kokkos-resilience",
       "cacheVariables": {
-        "Kokkos_ROOT": "/opt/view/gcc-11.4.0/kokkos/4.0.01/",
+        "Kokkos_ROOT": "/opt/view/gcc-11.4.0/kokkos/4.4.00/",
         "Boost_ROOT": "/opt/view/gcc-11.4.0/boost/1.81.0/",
         "veloc_ROOT": "/opt/veloc/",
         "KR_ENABLE_TESTS": "ON",

--- a/ci/spack.yaml
+++ b/ci/spack.yaml
@@ -2,7 +2,7 @@ spack:
   definitions:
     - compilers: [gcc@11.4.0]
     - packages:
-      - kokkos@4.0.01
+      - kokkos@4.4.00 +openmp
       - boost@1.81.0
   specs:
     - matrix:

--- a/ci/ubuntu20.04-gcc11-x64.dockerfile
+++ b/ci/ubuntu20.04-gcc11-x64.dockerfile
@@ -40,7 +40,7 @@ RUN apt-get update \
   && rm -rf /var/lib/apt/lists/*
 
 # Now we install spack and find compilers/externals
-RUN mkdir -p /opt/ && cd /opt/ && git clone --depth 1 --branch "v0.20.3" https://github.com/spack/spack.git
+RUN mkdir -p /opt/ && cd /opt/ && git clone --depth 1 https://github.com/spack/spack.git && cd spack && git checkout 1b0631b69edbc99a9527c1d6b9a913a49e3b1523
 ADD ./ci/packages.yaml /opt/spack/etc/spack/packages.yaml
 RUN . /opt/spack/share/spack/setup-env.sh && spack compiler find
 RUN . /opt/spack/share/spack/setup-env.sh && spack external find --not-buildable && spack external list


### PR DESCRIPTION
We need `+openmp` to properly test resilient execution spaces

Closes #73 