### PR TITLE
Change lambda capture test to only compile under `KR_ENABLE_AUTOMATIC_CHECKPOINTING` cmake option

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -21,8 +21,8 @@ endif()
 
 if (KR_ENABLE_AUTOMATIC_CHECKPOINTING)
   target_sources(resilience_tests PRIVATE
-     		 TestStdFileBackend.cpp)
-                 TestLambdaCapture.cpp
+     		 TestStdFileBackend.cpp
+                 TestLambdaCapture.cpp)
 endif()
 
 if (KR_ENABLE_STDFILE_DATA_SPACE)


### PR DESCRIPTION
Pull request to change lambda capture test to compile under auto checkpointing macro.