### PR TITLE
Split error injector into separate header file

### DIFF
--- a/src/resilience/exec_space/openMP/Resilient_OpenMP_Error_Injector.hpp
+++ b/src/resilience/exec_space/openMP/Resilient_OpenMP_Error_Injector.hpp
@@ -94,7 +94,7 @@ struct ErrorInjection
 {
   void error_injection(View& original, View& copy_0, View& copy_1)
   {
-#ifdef KR_ENABLE_TMR
+#ifdef KR_TRIPLE_MODULAR_REDUNDANCY
     //Any-dimensional TMR error injector
     size_t total_extent = 1;
     for(int i=0; i<= (int)CombineDuplicates::rank; i++){

--- a/src/resilience/exec_space/openMP/Resilient_OpenMP_Error_Injector.hpp
+++ b/src/resilience/exec_space/openMP/Resilient_OpenMP_Error_Injector.hpp
@@ -102,7 +102,6 @@ void error_injection(View& original, View& copy_0, View& copy_1)
 
   size_t next_inject = ErrorInjectionTracking::global_next_inject;
   std::array<size_t, 8> indices {};
-  //auto access = std::mem_fn(&View::access);
 
   for (int j = 0; j<=2; j++){
     while (next_inject < total_extent)
@@ -111,28 +110,19 @@ void error_injection(View& original, View& copy_0, View& copy_1)
       if (j==0){//Inject in the original if j is 0
         //replace value with noise
   	original.access(indices[0],indices[1],indices[2],indices[3],indices[4],indices[5],indices[6],indices[7])
-	//Incorrect because access expects individual indices, not a tuple.
-	//Hence the need to use apply with a tuple
-	//access(original, indices)
-	//auto tuple = std::make_tuple(original, indices); 
-	//std::apply(access, tuple) 
 		= static_cast<typename View::value_type>(ErrorInjectionTracking::random_gen());
         ErrorInjectionTracking::error_counter++;
       }
-//#if 0
       else if(j==1){//Else inject in one of the other two copies, copy[0]
 	copy_0.access(indices[0],indices[1],indices[2],indices[3],indices[5],indices[5],indices[6],indices[7])
-	//access(copy_0, indices)
 	          = static_cast<typename View::value_type>(ErrorInjectionTracking::random_gen());
         ErrorInjectionTracking::error_counter++;
       }
       else{//or copy[1]
 	copy_1.access(indices[0],indices[1],indices[2],indices[3],indices[5],indices[5],indices[6],indices[7])
-	//access(copy_1, indices)
 		  = static_cast<typename View::value_type>(ErrorInjectionTracking::random_gen());
         ErrorInjectionTracking::error_counter++;
       }
-//#endif
       next_inject = global_error_settings->geometric(ErrorInjectionTracking::random_gen)+next_inject+1;
     }
     if(total_extent != 1){

--- a/src/resilience/exec_space/openMP/Resilient_OpenMP_Error_Injector.hpp
+++ b/src/resilience/exec_space/openMP/Resilient_OpenMP_Error_Injector.hpp
@@ -82,7 +82,8 @@ auto get_inject_indices_array( const View &view, std::size_t next_inject ){
     next_inject_copy /= view.extent(i);
   }
 
-  return indices;
+  auto tuple_indices = std::tuple_cat(indices);
+  return tuple_indices;
 }
 
 template <typename View>	
@@ -100,27 +101,31 @@ void error_injection(View& original, View& copy_0, View& copy_1)
     }
   }
 
+  auto access = [](auto *view, auto... idcs) -> decltype (auto)
+                {return view->access(idcs...);};
   size_t next_inject = ErrorInjectionTracking::global_next_inject;
-  std::array<size_t, 8> indices {};
 
   for (int j = 0; j<=2; j++){
     while (next_inject < total_extent)
     {
-      indices = get_inject_indices_array( original, next_inject );
+      auto indices = get_inject_indices_array( original, next_inject );
       if (j==0){//Inject in the original if j is 0
+	auto view_tuple = std::tuple_cat(std::make_tuple(&original), indices);
         //replace value with noise
-  	original.access(indices[0],indices[1],indices[2],indices[3],indices[4],indices[5],indices[6],indices[7])
-		= static_cast<typename View::value_type>(ErrorInjectionTracking::random_gen());
+	std::apply(access, view_tuple)
+  	              = static_cast<typename View::value_type>(ErrorInjectionTracking::random_gen());
         ErrorInjectionTracking::error_counter++;
       }
       else if(j==1){//Else inject in one of the other two copies, copy[0]
-	copy_0.access(indices[0],indices[1],indices[2],indices[3],indices[5],indices[5],indices[6],indices[7])
-	          = static_cast<typename View::value_type>(ErrorInjectionTracking::random_gen());
+	auto view_tuple = std::tuple_cat(std::make_tuple(&copy_0), indices);
+	std::apply(access, view_tuple)
+    	            = static_cast<typename View::value_type>(ErrorInjectionTracking::random_gen());
         ErrorInjectionTracking::error_counter++;
       }
       else{//or copy[1]
-	copy_1.access(indices[0],indices[1],indices[2],indices[3],indices[5],indices[5],indices[6],indices[7])
-		  = static_cast<typename View::value_type>(ErrorInjectionTracking::random_gen());
+	auto view_tuple = std::tuple_cat(std::make_tuple(&copy_1), indices);
+	std::apply(access, view_tuple)
+    	            = static_cast<typename View::value_type>(ErrorInjectionTracking::random_gen());
         ErrorInjectionTracking::error_counter++;
       }
       next_inject = global_error_settings->geometric(ErrorInjectionTracking::random_gen)+next_inject+1;

--- a/src/resilience/exec_space/openMP/Resilient_OpenMP_Error_Injector.hpp
+++ b/src/resilience/exec_space/openMP/Resilient_OpenMP_Error_Injector.hpp
@@ -1,0 +1,163 @@
+/*
+ *
+ *                        Kokkos v. 3.0
+ *       Copyright (2020) National Technology & Engineering
+ *               Solutions of Sandia, LLC (NTESS).
+ *
+ * Under the terms of Contract DE-NA0003525 with NTESS,
+ * the U.S. Government retains certain rights in this software.
+ *
+ * Kokkos is licensed under 3-clause BSD terms of use:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the Corporation nor the names of the
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+ */
+#ifndef INC_RESILIENCE_OPENMP_ERROR_INJECTOR_HPP
+#define INC_RESILIENCE_OPENMP_ERROR_INJECTOR_HPP
+
+#include <Kokkos_Macros.hpp>
+#if defined(KOKKOS_ENABLE_OPENMP)
+
+#include "Resilient_OpenMP_Subscriber.hpp"
+//#if 0
+namespace KokkosResilience{
+
+// Struct to gate error insertion
+struct Error{
+explicit Error(double rate) : error_rate(rate), geometric(rate){}
+
+double error_rate;
+std::geometric_distribution<> geometric{error_rate};
+
+};
+
+inline std::optional<Error> global_error_settings;
+
+struct ErrorInjectionTracking{
+inline static int64_t error_counter;
+inline static std::mt19937 random_gen{0};
+inline static size_t global_next_inject = 0;
+//Error timer settings zero-initialized
+inline static std::chrono::duration<long int, std::nano> elapsed_seconds{};
+inline static std::chrono::duration<long int, std::nano> total_error_time{};
+inline static std::mutex global_time_mutex;
+};
+
+// Calculates coordinate formulas from linear iterator
+template< typename View>
+auto get_inject_indices_array( const View &view, std::size_t next_inject ){
+
+  std::array<std::size_t, 8> indices {};
+  size_t dim_product = 1;
+
+  // View.extent() returns 1 for uninitialized dimensions
+  // this array returns accurate coordinates up to the existing view rank
+  // coordinates past rank are inaccurate, but are truncated by view.access() in the main injector
+  indices[0] = next_inject % view.extent(0);
+
+  for(int i=1;i<8;i++){
+    indices[i] = ((next_inject - (indices[i-1] * dim_product)) / (dim_product * view.extent(i-1) )) % view.extent(i);
+    dim_product = dim_product * view.extent(i-1);
+  }
+
+  return indices;
+}
+
+template <typename View, typename CombineDuplicates>
+struct ErrorInjection
+{
+  void error_injection(View& original, View& copy_0, View& copy_1)
+  {
+#ifdef KR_ENABLE_TMR
+    //Any-dimensional TMR error injector
+    size_t total_extent = 1;
+    for(int i=0; i<= (int)CombineDuplicates::rank; i++){
+      total_extent = total_extent * original.extent(i);
+    }
+
+    //requires error in range, unless view size too small
+    if (total_extent !=1 && (ErrorInjectionTracking::global_next_inject > total_extent))
+    {
+      while (ErrorInjectionTracking::global_next_inject>total_extent){
+        ErrorInjectionTracking::global_next_inject = ErrorInjectionTracking::global_next_inject - total_extent;
+      }
+    }
+
+    size_t next_inject = ErrorInjectionTracking::global_next_inject;
+    std::array<size_t, 8> indices {};
+
+    for (int j = 0; j<=2; j++){
+      while (next_inject < total_extent)
+      {
+        indices = get_inject_indices_array( original, next_inject );
+        if (j==0){//Inject in the original if j is 0
+          //replace value with noise
+  	  original.access(indices[0],indices[1],indices[2],indices[3],indices[4],indices[5],indices[6],indices[7])
+                   = static_cast<typename View::value_type>(ErrorInjectionTracking::random_gen());
+          ErrorInjectionTracking::error_counter++;
+        }
+        else if(j==1){//Else inject in one of the other two copies, copy[0]
+	  copy_0.access(indices[0],indices[1],indices[2],indices[3],indices[5],indices[5],indices[6],indices[7])
+                   = static_cast<typename View::value_type>(ErrorInjectionTracking::random_gen());
+          ErrorInjectionTracking::error_counter++;
+	}
+	else{//or copy[1]
+	  copy_1.access(indices[0],indices[1],indices[2],indices[3],indices[5],indices[5],indices[6],indices[7])
+                   = static_cast<typename View::value_type>(ErrorInjectionTracking::random_gen());
+          ErrorInjectionTracking::error_counter++;
+        }
+        next_inject = global_error_settings->geometric(ErrorInjectionTracking::random_gen)+next_inject+1;
+      }
+      if(total_extent != 1){
+        next_inject = next_inject - total_extent;
+      }
+    }
+#endif
+  }// end inject_error
+
+};
+
+KOKKOS_INLINE_FUNCTION
+void print_total_error_time() {
+
+  ErrorInjectionTracking::global_time_mutex.lock();
+  std::cout << "The value of ErrorInjectionTracking::total_error_time.count() is " << ErrorInjectionTracking::total_error_time.count() << " nanoseconds." << std::endl;
+  std::cout << "The total number of errors inserted is " << ErrorInjectionTracking::error_counter << " errors." << std::endl;
+  ErrorInjectionTracking::global_time_mutex.unlock();
+
+}
+
+}//KokkosResilience
+
+#endif //defined(KOKKOS_ENABLE_OPENMP)
+#endif //INC_RESILIENCE_OPENMP_ERROR_INJECTOR_HPP
+
+
+
+

--- a/src/resilience/exec_space/openMP/Resilient_OpenMP_Parallel_For.hpp
+++ b/src/resilience/exec_space/openMP/Resilient_OpenMP_Parallel_For.hpp
@@ -52,6 +52,7 @@
 #include <Kokkos_Core.hpp>
 
 #include "Resilient_OpenMP_Subscriber.hpp"
+#include "Resilient_OpenMP_Error_Injector.hpp"
 
 /*--------------------------------------------------------------------------*/
 /************************** DUPLICATE COMBINER CALL *************************/
@@ -83,8 +84,7 @@ namespace KokkosResilience{
 
     if (global_error_settings){
       //Per kernel, seed the first inject index	    
-      KokkosResilience::ErrorInject::global_next_inject = KokkosResilience::global_error_settings->geometric(KokkosResilience::ErrorInject::random_gen);	      ;
-
+      KokkosResilience::ErrorInjectionTracking::global_next_inject = KokkosResilience::global_error_settings->geometric(KokkosResilience::ErrorInjectionTracking::random_gen);
       // Inject geometrically distributed error into all duplicates
       // Go over the Subscriber map, inject into all the CombinerBase elements
       for (auto&& combiner : KokkosResilience::ResilientDuplicatesSubscriber::duplicates_map) {
@@ -212,8 +212,8 @@ class ParallelFor< FunctorType
       const auto start{std::chrono::steady_clock::now()};
       KokkosResilience::inject_error_duplicates();
       const auto stop{std::chrono::steady_clock::now()};
-      KokkosResilience::ErrorTimerSettings::elapsed_seconds = KokkosResilience::ErrorTimerSettings::elapsed_seconds + (std::chrono::duration_cast<std::chrono::nanoseconds>(stop - start));
-      KokkosResilience::ErrorTimerSettings::total_error_time = KokkosResilience::ErrorTimerSettings::total_error_time + KokkosResilience::ErrorTimerSettings::elapsed_seconds;
+      KokkosResilience::ErrorInjectionTracking::elapsed_seconds = KokkosResilience::ErrorInjectionTracking::elapsed_seconds + (std::chrono::duration_cast<std::chrono::nanoseconds>(stop - start));
+      KokkosResilience::ErrorInjectionTracking::total_error_time = KokkosResilience::ErrorInjectionTracking::total_error_time + KokkosResilience::ErrorInjectionTracking::elapsed_seconds;
 
       // Combine the duplicate views and majority vote on correctness
       success = KokkosResilience::combine_resilient_duplicates();
@@ -241,8 +241,8 @@ class ParallelFor< FunctorType
       const auto start{std::chrono::steady_clock::now()};
       KokkosResilience::inject_error_duplicates();
       const auto stop{std::chrono::steady_clock::now()};
-      KokkosResilience::ErrorTimerSettings::elapsed_seconds = KokkosResilience::ErrorTimerSettings::elapsed_seconds + (std::chrono::duration_cast<std::chrono::nanoseconds>(stop - start));
-      KokkosResilience::ErrorTimerSettings::total_error_time = KokkosResilience::ErrorTimerSettings::total_error_time + KokkosResilience::ErrorTimerSettings::elapsed_seconds;
+      KokkosResilience::ErrorInjectionTracking::elapsed_seconds = KokkosResilience::ErrorInjectionTracking::elapsed_seconds + (std::chrono::duration_cast<std::chrono::nanoseconds>(stop - start));
+      KokkosResilience::ErrorInjectionTracking::total_error_time = KokkosResilience::ErrorInjectionTracking::total_error_time + KokkosResilience::ErrorInjectionTracking::elapsed_seconds;
       
       // Combine the duplicate views, majority vote not triggered due to CMAKE macro
       success = KokkosResilience::combine_resilient_duplicates();
@@ -259,8 +259,8 @@ class ParallelFor< FunctorType
         start=std::chrono::steady_clock::now();
         KokkosResilience::inject_error_duplicates();
         stop=std::chrono::steady_clock::now();
-        KokkosResilience::ErrorTimerSettings::elapsed_seconds = KokkosResilience::ErrorTimerSettings::elapsed_seconds + (std::chrono::duration_cast<std::chrono::nanoseconds>(stop - start));
-        KokkosResilience::ErrorTimerSettings::total_error_time = KokkosResilience::ErrorTimerSettings::total_error_time + KokkosResilience::ErrorTimerSettings::elapsed_seconds;
+        KokkosResilience::ErrorInjectionTracking::elapsed_seconds = KokkosResilience::ErrorInjectionTracking::elapsed_seconds + (std::chrono::duration_cast<std::chrono::nanoseconds>(stop - start));
+        KokkosResilience::ErrorInjectionTracking::total_error_time = KokkosResilience::ErrorInjectionTracking::total_error_time + KokkosResilience::ErrorInjectionTracking::elapsed_seconds;
 
         success = KokkosResilience::combine_resilient_duplicates();
         KokkosResilience::clear_duplicates_map();
@@ -280,8 +280,8 @@ class ParallelFor< FunctorType
       const auto start{std::chrono::steady_clock::now()};
       KokkosResilience::inject_error_duplicates();
       const auto stop{std::chrono::steady_clock::now()};
-      KokkosResilience::ErrorTimerSettings::elapsed_seconds = KokkosResilience::ErrorTimerSettings::elapsed_seconds + (std::chrono::duration_cast<std::chrono::nanoseconds>(stop - start));
-      KokkosResilience::ErrorTimerSettings::total_error_time = KokkosResilience::ErrorTimerSettings::total_error_time + KokkosResilience::ErrorTimerSettings::elapsed_seconds;
+      KokkosResilience::ErrorInjectionTracking::elapsed_seconds = KokkosResilience::ErrorInjectionTracking::elapsed_seconds + (std::chrono::duration_cast<std::chrono::nanoseconds>(stop - start));
+      KokkosResilience::ErrorInjectionTracking::total_error_time = KokkosResilience::ErrorInjectionTracking::total_error_time + KokkosResilience::ErrorInjectionTracking::elapsed_seconds;
 
       // Combine the duplicate views and majority vote on correctness
       success = KokkosResilience::combine_resilient_duplicates();

--- a/src/resilience/exec_space/openMP/Resilient_OpenMP_Parallel_For.hpp
+++ b/src/resilience/exec_space/openMP/Resilient_OpenMP_Parallel_For.hpp
@@ -174,7 +174,7 @@ class ParallelFor< FunctorType
 
       surrogate_policy wrapper_policy;
       
-#if KR_TRIPLE_MODULAR_REDUNDANCY
+#ifdef KR_TRIPLE_MODULAR_REDUNDANCY
       wrapper_policy = surrogate_policy(m_policy.begin(), m_policy.end());
       // Trigger Subscriber constructors
       KokkosResilience::ResilientDuplicatesSubscriber::in_resilient_parallel_loop = true;

--- a/src/resilience/exec_space/openMP/Resilient_OpenMP_Parallel_For.hpp
+++ b/src/resilience/exec_space/openMP/Resilient_OpenMP_Parallel_For.hpp
@@ -212,8 +212,8 @@ class ParallelFor< FunctorType
       const auto start{std::chrono::steady_clock::now()};
       KokkosResilience::inject_error_duplicates();
       const auto stop{std::chrono::steady_clock::now()};
-      KokkosResilience::ErrorInjectionTracking::elapsed_seconds = KokkosResilience::ErrorInjectionTracking::elapsed_seconds + (std::chrono::duration_cast<std::chrono::nanoseconds>(stop - start));
-      KokkosResilience::ErrorInjectionTracking::total_error_time = KokkosResilience::ErrorInjectionTracking::total_error_time + KokkosResilience::ErrorInjectionTracking::elapsed_seconds;
+      KokkosResilience::ErrorInjectionTracking::elapsed_seconds = (std::chrono::duration_cast<std::chrono::nanoseconds>(stop - start));
+      KokkosResilience::ErrorInjectionTracking::total_error_time += KokkosResilience::ErrorInjectionTracking::elapsed_seconds;
 
       // Combine the duplicate views and majority vote on correctness
       success = KokkosResilience::combine_resilient_duplicates();
@@ -241,8 +241,8 @@ class ParallelFor< FunctorType
       const auto start{std::chrono::steady_clock::now()};
       KokkosResilience::inject_error_duplicates();
       const auto stop{std::chrono::steady_clock::now()};
-      KokkosResilience::ErrorInjectionTracking::elapsed_seconds = KokkosResilience::ErrorInjectionTracking::elapsed_seconds + (std::chrono::duration_cast<std::chrono::nanoseconds>(stop - start));
-      KokkosResilience::ErrorInjectionTracking::total_error_time = KokkosResilience::ErrorInjectionTracking::total_error_time + KokkosResilience::ErrorInjectionTracking::elapsed_seconds;
+      KokkosResilience::ErrorInjectionTracking::elapsed_seconds = (std::chrono::duration_cast<std::chrono::nanoseconds>(stop - start));
+      KokkosResilience::ErrorInjectionTracking::total_error_time += KokkosResilience::ErrorInjectionTracking::elapsed_seconds;
       
       // Combine the duplicate views, majority vote not triggered due to CMAKE macro
       success = KokkosResilience::combine_resilient_duplicates();
@@ -259,8 +259,8 @@ class ParallelFor< FunctorType
         start=std::chrono::steady_clock::now();
         KokkosResilience::inject_error_duplicates();
         stop=std::chrono::steady_clock::now();
-        KokkosResilience::ErrorInjectionTracking::elapsed_seconds = KokkosResilience::ErrorInjectionTracking::elapsed_seconds + (std::chrono::duration_cast<std::chrono::nanoseconds>(stop - start));
-        KokkosResilience::ErrorInjectionTracking::total_error_time = KokkosResilience::ErrorInjectionTracking::total_error_time + KokkosResilience::ErrorInjectionTracking::elapsed_seconds;
+        KokkosResilience::ErrorInjectionTracking::elapsed_seconds = (std::chrono::duration_cast<std::chrono::nanoseconds>(stop - start));
+        KokkosResilience::ErrorInjectionTracking::total_error_time += KokkosResilience::ErrorInjectionTracking::elapsed_seconds;
 
         success = KokkosResilience::combine_resilient_duplicates();
         KokkosResilience::clear_duplicates_map();
@@ -280,8 +280,8 @@ class ParallelFor< FunctorType
       const auto start{std::chrono::steady_clock::now()};
       KokkosResilience::inject_error_duplicates();
       const auto stop{std::chrono::steady_clock::now()};
-      KokkosResilience::ErrorInjectionTracking::elapsed_seconds = KokkosResilience::ErrorInjectionTracking::elapsed_seconds + (std::chrono::duration_cast<std::chrono::nanoseconds>(stop - start));
-      KokkosResilience::ErrorInjectionTracking::total_error_time = KokkosResilience::ErrorInjectionTracking::total_error_time + KokkosResilience::ErrorInjectionTracking::elapsed_seconds;
+      KokkosResilience::ErrorInjectionTracking::elapsed_seconds = (std::chrono::duration_cast<std::chrono::nanoseconds>(stop - start));
+      KokkosResilience::ErrorInjectionTracking::total_error_time += KokkosResilience::ErrorInjectionTracking::elapsed_seconds;
 
       // Combine the duplicate views and majority vote on correctness
       success = KokkosResilience::combine_resilient_duplicates();

--- a/src/resilience/exec_space/openMP/Resilient_OpenMP_Subscriber.hpp
+++ b/src/resilience/exec_space/openMP/Resilient_OpenMP_Subscriber.hpp
@@ -156,9 +156,8 @@ struct CombineDuplicates: public CombineDuplicatesBase
 
   static constexpr size_t rank = View::rank();
 
-  ErrorInjection<View, CombineDuplicates> error_container;
   void inject_error() override{
-    error_container.error_injection(original, copy[0], copy[1]);  
+    error_injection(original, copy[0], copy[1]);
   }
 
   void clear() override

--- a/tests/TestOpenMPResilientExecution.cpp
+++ b/tests/TestOpenMPResilientExecution.cpp
@@ -117,7 +117,7 @@ TEST(TestResOpenMP, TestResilientForDouble)
   });
   //reset global error settings
   KokkosResilience::print_total_error_time();
-  KokkosResilience::ErrorInject::error_counter=0;
+  KokkosResilience::ErrorInjectionTracking::error_counter=0;
   KokkosResilience::global_error_settings.reset();
   KokkosResilience::clear_duplicates_cache();
   
@@ -175,7 +175,7 @@ TEST(TestResOpenMP, TestErrorHandler)
   KokkosResilience::set_unrecoverable_data_corruption_handler(
       [&failed_recovery](std::size_t) { failed_recovery = true; });
  
-  KokkosResilience::ErrorInject::error_counter = 0;
+  KokkosResilience::ErrorInjectionTracking::error_counter = 0;
   //Set an extremely high error rate that the test cannot recover from
   //Half of all values are errors
   KokkosResilience::global_error_settings = KokkosResilience::Error(0.5);
@@ -293,7 +293,7 @@ TEST(TestResOpenMP, TestKokkos2D)
 TEST(TestResOpenMP, TestResilient2D)
 {
 
-  KokkosResilience::ErrorInject::error_counter = 0;
+  KokkosResilience::ErrorInjectionTracking::error_counter = 0;
   KokkosResilience::global_error_settings = KokkosResilience::Error(0.0001);
 	
   // Allocate y, x vectors.
@@ -310,7 +310,7 @@ TEST(TestResOpenMP, TestResilient2D)
 
   KokkosResilience::print_total_error_time();
   KokkosResilience::clear_duplicates_cache(); 
-  KokkosResilience::ErrorInject::error_counter = 0;
+  KokkosResilience::ErrorInjectionTracking::error_counter = 0;
   KokkosResilience::global_error_settings.reset();
 
   Kokkos::deep_copy(x, y);
@@ -401,8 +401,8 @@ TEST(TestResOpenMP, TestMiniMDKernel)
 //Test MiniMD Exact Kernel Behavior with Resilience
 TEST(TestResOpenMP, TestMiniMDKernelResilient)
 {
-  KokkosResilience::ErrorInject::error_counter = 0;
-  std::cout << "ErrorInject::error_counter is " << KokkosResilience::ErrorInject::error_counter << "\n";
+  KokkosResilience::ErrorInjectionTracking::error_counter = 0;
+  std::cout << "ErrorInjectionTracking::error_counter is " << KokkosResilience::ErrorInjectionTracking::error_counter << "\n";
   std::cout << "This is the test of minMD 2D Resilient Error Injection \n\n\n";
   KokkosResilience::global_error_settings = KokkosResilience::Error(0.001);
 
@@ -434,7 +434,7 @@ TEST(TestResOpenMP, TestMiniMDKernelResilient)
 
   KokkosResilience::print_total_error_time();
   KokkosResilience::clear_duplicates_cache();
-  KokkosResilience::ErrorInject::error_counter=0;
+  KokkosResilience::ErrorInjectionTracking::error_counter=0;
   KokkosResilience::global_error_settings.reset();
 
   std::cout << std::endl <<std::endl;


### PR DESCRIPTION
PR proposes the following changes:

- Splitting the error injection machinery into a separate header file
- Renaming some error injection variables to support streamlining the injection structs
- Streamlining the injection structs
- Some minor code changes to support moving the code to a separate header