### PR TITLE
Bugfix resilienceConfig.cmake.in

### DIFF
--- a/cmake/resilienceConfig.cmake.in
+++ b/cmake/resilienceConfig.cmake.in
@@ -8,8 +8,8 @@ include("${CMAKE_CURRENT_LIST_DIR}/resilienceTargets.cmake")
 #All options defined with kr_option are exposed to linking targets' CMakeLists
 set(KR_EXPOSED_OPTIONS @KR_EXPOSED_OPTIONS@)
 set(KR_EXPOSED_OPTION_VALUES @KR_EXPOSED_OPTION_VALUES@)
-foreach (OPT_1 OPT_2 IN ZIP_LISTS KR_EXPOSED_OPTIONS KR_EXPOSED_OPTION_VALUES)
-   set(${OPT_1} ${OPT_2})
+foreach (OPT VAL in ZIP_LISTS KR_EXPOSED_OPTIONS KR_EXPOSED_OPTION_VALUES)
+	set(${OPT} ${VAL})
 endforeach()
 
 # VeloC needs to add a cmake config...


### PR DESCRIPTION
Small bugfix to reslienceConfig.cmake.in to prevent list of kr_exposed_options from being empty when other cmake projects find the resilience package.