### PR TITLE
Use std::stringstream as scratch buffer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,7 +57,7 @@ target_include_directories(resilience PUBLIC
 find_package(Kokkos 4.0 REQUIRED)
 find_package(Boost REQUIRED)
 
-set_property(TARGET resilience PROPERTY CXX_STANDARD ${Kokkos_CXX_STANDARD})
+target_compile_features(resilience PUBLIC cxx_std_20)
 target_link_libraries(resilience PUBLIC Kokkos::kokkos Boost::boost)
 
 #Make individual variables for available Kokkos devices

--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@ and checkpointing to scientific applications.
 
 ## Building
 
-*Kokkos Resilience* is built using [CMake](https://cmake.org) version 3.17 or later. It has been tested on
-compilers such as GCC 11.2.0 and LLVM/Clang 11.0.0. It should work on any C++14 supporting compiler, but your mileage
-may vary.
+*Kokkos Resilience* is built using [CMake](https://cmake.org) version 3.17 or later.
+Any compiler that supports C++20 should work, but your mileage may vary.
+Automatic CI testing verifies compatibility with GCC 11.4.0.
 
 ### Dependencies
 

--- a/src/resilience/context/Context.hpp
+++ b/src/resilience/context/Context.hpp
@@ -97,10 +97,24 @@ namespace KokkosResilience
     //Pointer not guaranteed to remain valid, use immediately & discard.
     char* get_scratch_buffer(size_t minimum_size);
 
+    //Contents not guaranteed to remain valid, write and use immediately.
+    //Note: since this stringstream is reused, its view() may be longer than the
+    //  number of bytes written since obtaining the stream. Use tellp() to get
+    //  the size of written data
+    std::stringstream& get_scratch_stream();
+
+    // Get view of the scratch stream sized correctly with tellp()
+    // Not guaranteed to remain valid, use immediately & discard.
+    std::string_view cur_scratch_view() {
+      return m_scratch_buffer.view().substr(0, m_scratch_buffer.tellp());
+    }
+
   private:
     
     //Hold onto a buffer per context for de/serializing non-contiguous or non-host views.
-    std::vector<char> m_scratch_buffer;
+    std::stringstream m_scratch_buffer{
+      std::ios_base::in | std::ios_base::out | std::ios_base::binary
+    };
 
     Config m_config;
 


### PR DESCRIPTION
Uses a stringstream as ContextBase's scratch buffer, to avoid some extra copies for the upcoming Fenix backend