### PR TITLE
Clean up dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,10 +55,9 @@ target_include_directories(resilience PUBLIC
                            )
 
 find_package(Kokkos 4.0 REQUIRED)
-find_package(Boost REQUIRED)
 
 set_property(TARGET resilience PROPERTY CXX_STANDARD ${Kokkos_CXX_STANDARD})
-target_link_libraries(resilience PUBLIC Kokkos::kokkos Boost::boost)
+target_link_libraries(resilience PUBLIC Kokkos::kokkos)
 
 #Make individual variables for available Kokkos devices
 foreach(DEVICE ${Kokkos_DEVICES})
@@ -76,8 +75,8 @@ kr_option(KR_ENABLE_AUTOMATIC_CHECKPOINTING "Compile automatic checkpointing con
 #Consistency contexts
 kr_option(KR_ENABLE_MPI_CONTEXT "Compile MPI checkpointing context" ON KR_ENABLE_AUTOMATIC_CHECKPOINTING)
 #Backends
-kr_option(KR_ENABLE_VELOC_BACKEND "Compile VeloC checkpointing backend" ON KR_ENABLE_MPI_CONTEXT)
-kr_option(KR_VELOC_BAREBONE "Use the barebone branch of VeloC" OFF KR_ENABLE_VELOC)
+find_package(veloc QUIET)
+kr_option(KR_ENABLE_VELOC_BACKEND "Compile VeloC checkpointing backend" ${veloc_FOUND} KR_ENABLE_MPI_CONTEXT)
 
 #Data space options
 kr_option(KR_ENABLE_DATA_SPACES "Enable Kokkos memory spaces for manual view checkpointing" OFF)
@@ -108,19 +107,26 @@ kr_option(KR_KERNEL_FUSING "enable kernel fusing" OFF "KR_ENABLE_OPENMP_EXEC_SPA
 
 # VeloC backend
 if (KR_ENABLE_VELOC_BACKEND)
-  find_package(veloc REQUIRED)
+  if (NOT veloc_FOUND)
+    message(FATAL_ERROR "Veloc backend requested, but veloc not found!")
+  endif()
   target_link_libraries(resilience PUBLIC veloc::client)
 endif()
 
+if (KR_ENABLE_DATA_SPACES)
+  find_package(Boost REQUIRED)
+  target_link_libraries(resilience PUBLIC Boost::boost)
+endif()
+
 if (KR_ENABLE_HDF5_DATA_SPACE)
-   find_package(HDF5 REQUIRED)
-   target_link_libraries(resilience PUBLIC HDF5::HDF5)
+  find_package(HDF5 REQUIRED)
+  target_link_libraries(resilience PUBLIC HDF5::HDF5)
 endif()
 
 # MPI requirement
 if (KR_ENABLE_MPI_CONTEXT OR KR_ENABLE_HDF5_PARALLEL)
-   find_package(MPI REQUIRED)
-   target_link_libraries(resilience PRIVATE MPI::MPI_CXX)
+  find_package(MPI REQUIRED)
+  target_link_libraries(resilience PRIVATE MPI::MPI_CXX)
 endif()
 
 if (KR_ENABLE_OPENMP_EXEC_SPACE)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -10,10 +10,6 @@
       "name": "kr_auto_checkpoint_veloc",
       "hidden": true,
       "cacheVariables": {
-        "KR_VELOC_BAREBONE": {
-          "type": "BOOL",
-          "value": "OFF"
-        },
         "KR_ENABLE_VELOC_BACKEND": {
           "type": "BOOL",
           "value": "ON"

--- a/README.md
+++ b/README.md
@@ -20,24 +20,12 @@ other software (such as Trilinos) or as a package on a machine.
 
 #### Boost
 
-Kokkos-resilience uses Boost for a replacement for some C++17 features such as the filesystem library, `std::optional`, and `std::variant`.
-This dependency will likely be removed in the future when Kokkos requires C++17.
+*Kokkos Resilience* depends on Boost when KR_ENABLE_DATA_SPACES is enabled.
 
 #### VeloC
 
-Additionally, *Kokkos Resilience* uses the [Veloc](https://github.com/ECP-VeloC/VELOC) library for efficient asynchronous
-checkpointing. If you desire automatic checkpointing to be available this library (and additionally MPI) must be installed.
-
-We are maintaining a special spack package for VeloC since the main one is not up-to-date. It can be found
-[here](https://gitlab-ex.sandia.gov/kokkos-resilience/kr-spack) and can be installed via:
-
-```sh
-git clone git@gitlab-ex.sandia.gov:kokkos-resilience/kr-spack.git
-spack repo add kr-spack
-spack install veloc@barebone
-```
-
-It is recommended to install the "barebone" variant/branch of VeloC since it has reduced dependencies.
+*Kokkos Resilience* optionally uses the [Veloc](https://github.com/ECP-VeloC/VELOC) library for efficient asynchronous
+checkpointing.
 
 ### CMake Invocation
 
@@ -60,7 +48,6 @@ need at least CMake 3.21.
 | Variable                | Default | Description                                        |
 | ----------------------- | ------- | -------------------------------------------------- |
 | KR_ENABLE_VELOC         | ON      | Enables the VeloC backend                          |
-| KR_VELOC_BAREBONE       | OFF     | Enable VeloC barebone mode                         |
 | KR_ENABLE_TRACING       | OFF     | Enable performance tracing of resilience functions |
 | KR_ENABLE_STDIO         | OFF     | Use stdio for manual checkpoint                    |
 | KR_ENABLE_HDF5          | OFF     | Add HDF5 support for manual checkpoint             |

--- a/cmake/resilienceConfig.cmake.in
+++ b/cmake/resilienceConfig.cmake.in
@@ -23,10 +23,12 @@ if (KR_ENABLE_VELOC_BACKEND)
    find_dependency(veloc REQUIRED)
 endif()
 
+if (KR_ENABLE_DATA_SPACES)
+   set(Boost_DIR @Boost_DIR@)
+   find_dependency(Boost REQUIRED)
+endif()
+
 if (KR_ENABLE_HDF5_DATA_SPACE)
    set(HDF5_DIR @HDF5_DIR@)
    find_dependency(HDF5 REQUIRED)
 endif()
-
-set(Boost_DIR @Boost_DIR@)
-find_dependency(Boost REQUIRED)

--- a/src/resilience/util/filesystem/CMakeLists.txt
+++ b/src/resilience/util/filesystem/CMakeLists.txt
@@ -1,4 +1,9 @@
 target_sources(resilience PRIVATE
-               ${CMAKE_CURRENT_LIST_DIR}/ExternalIOInterface.cpp
                ${CMAKE_CURRENT_LIST_DIR}/Filesystem.cpp
                )
+
+if (KR_ENABLE_DATA_SPACES)
+    target_sources(resilience PRIVATE
+                   ${CMAKE_CURRENT_LIST_DIR}/ExternalIOInterface.cpp
+                   )
+endif()


### PR DESCRIPTION
Drops Boost unless building with data spaces
sets VeloC backend's default enable state based on if the package is found
drops references to VeloC BAREBONES