### PR TITLE
Remove register step from backends

### DIFF
--- a/src/resilience/backend/StdFileBackend.hpp
+++ b/src/resilience/backend/StdFileBackend.hpp
@@ -72,8 +72,6 @@ class StdFileBackend {
 
   void reset() {}
 
-  void register_hashes(std::unordered_set<Registration> &members) {}
-
  private:
   std::string m_filename;
   StdFileContext<StdFileBackend> &m_context;

--- a/src/resilience/backend/VelocBackend.cpp
+++ b/src/resilience/backend/VelocBackend.cpp
@@ -99,8 +99,7 @@ namespace KokkosResilience
   {
     VELOC_SAFE_CALL(veloc_client->checkpoint_wait());
 
-    bool success;
-    success = VELOC_SAFE_CALL(veloc_client->checkpoint_begin(label, version));
+    bool success = VELOC_SAFE_CALL(veloc_client->checkpoint_begin(label, version));
     
     if(success){
       std::set<int> ids = protect_members(members);
@@ -139,8 +138,7 @@ namespace KokkosResilience
   VeloCMemoryBackend::restart( const std::string &label, int version,
                                std::unordered_set<Registration> &members )
   {
-    bool success;
-    success = VELOC_SAFE_CALL(veloc_client->restart_begin(label, version));
+    bool success = VELOC_SAFE_CALL(veloc_client->restart_begin(label, version));
 
     if(success){
       std::set<int> ids = protect_members(members);

--- a/src/resilience/backend/VelocBackend.hpp
+++ b/src/resilience/backend/VelocBackend.hpp
@@ -87,41 +87,21 @@ namespace KokkosResilience
 
     void clear_checkpoints();
 
-    void register_hashes( std::unordered_set<Registration> &members );
-
     void reset();
-    void register_alias( const std::string &original, const std::string &alias );
-
-    std::set<int> hash_set(std::unordered_set<Registration> &members);
+    void register_alias( Registration& member, const std::string &alias );
 
   private:
+    int protect_member(Registration member);
+    std::set<int> protect_members(std::unordered_set<Registration>& members);
+    void unprotect_members(const std::set<int>& ids);
+
     ContextBase *m_context;
     MPI_Comm m_mpi_comm;
 
     veloc::client_t *veloc_client;
 
     mutable std::unordered_map< std::string, int > m_latest_version;
-    std::unordered_map< std::string, int > m_alias_map;
-  };
-
-  class VeloCRegisterOnlyBackend : public VeloCMemoryBackend
-  {
-   public:
-
-    using VeloCMemoryBackend::VeloCMemoryBackend;
-    ~VeloCRegisterOnlyBackend() = default;
-
-    VeloCRegisterOnlyBackend( const VeloCRegisterOnlyBackend & ) = delete;
-    VeloCRegisterOnlyBackend( VeloCRegisterOnlyBackend && ) noexcept = default;
-
-    VeloCRegisterOnlyBackend &operator=( const VeloCRegisterOnlyBackend & ) = delete;
-    VeloCRegisterOnlyBackend &operator=( VeloCRegisterOnlyBackend && ) = default;
-
-    void checkpoint( const std::string &label, int version,
-                     std::unordered_set<Registration> &members );
-
-    void restart( const std::string &label, int version,
-                  std::unordered_set<Registration> &members );
+    std::unordered_map< std::string, Registration > m_alias_map;
   };
 
   class VeloCFileBackend
@@ -140,8 +120,6 @@ namespace KokkosResilience
     void restart( const std::string &label, int version,
                   std::unordered_set<Registration> &members );
 
-    void register_hashes( std::unordered_set<Registration> &members ) {} // Do nothing
-    
     veloc::client_t *veloc_client;
     
     ContextBase *m_context;

--- a/src/resilience/context/Context.cpp
+++ b/src/resilience/context/Context.cpp
@@ -118,9 +118,6 @@ namespace KokkosResilience
 #ifdef KR_ENABLE_VELOC_BACKEND
         {"veloc", [&]() -> std::unique_ptr<ContextBase> {
           return std::make_unique<MPIContext<VeloCMemoryBackend> >(comm, cfg);
-        }},
-        {"veloc-noop", [&]() -> std::unique_ptr<ContextBase> {
-          return std::make_unique<MPIContext<VeloCRegisterOnlyBackend> >(comm, cfg);
         }}
 #endif
       };

--- a/src/resilience/context/Context.hpp
+++ b/src/resilience/context/Context.hpp
@@ -73,7 +73,7 @@ namespace KokkosResilience
     explicit ContextBase( Config cfg );
 
     virtual ~ContextBase() = default;
-    virtual void register_hashes(std::unordered_set<Registration> &members) = 0;
+    virtual void register_hashes(std::unordered_set<Registration> &members) {};
     virtual bool restart_available( const std::string &label, int version ) = 0;
     virtual void restart( const std::string &label, int version,
                           std::unordered_set<Registration> &members) = 0;

--- a/src/resilience/context/MPIContext.hpp
+++ b/src/resilience/context/MPIContext.hpp
@@ -88,10 +88,6 @@ public:
 
   Backend &backend() { return m_backend; }
 
-  void register_hashes(std::unordered_set<Registration> &members) override {
-    m_backend.register_hashes(members);
-  }
-
   bool restart_available(const std::string &label, int version) override {
     return m_backend.restart_available(label, version);
   }
@@ -111,7 +107,7 @@ public:
   }
 
   void register_alias( const std::string &original, const std::string &alias ) override {
-    return m_backend.register_alias( original, alias );
+  
   }
 
   void reset() override { m_backend.reset(); }

--- a/src/resilience/context/StdFileContext.hpp
+++ b/src/resilience/context/StdFileContext.hpp
@@ -84,10 +84,6 @@ class StdFileContext : public ContextBase {
 
   Backend &backend() { return m_backend; }
 
-  void register_hashes(std::unordered_set<Registration> &members) override {
-    m_backend.register_hashes(members);
-  }
-
   bool restart_available(const std::string &label, int version) override {
     return m_backend.restart_available(label, version);
   }


### PR DESCRIPTION
Leaving register as a context function call though, we'll use it later.